### PR TITLE
Reconnecting to an existing, populated store

### DIFF
--- a/RDF-Trine/lib/RDF/Trine/Store/DBI.pm
+++ b/RDF-Trine/lib/RDF/Trine/Store/DBI.pm
@@ -111,6 +111,7 @@ sub new {
 	
 	my $name	= shift || 'model';
 	my %args;
+	my $reconnect;
 	if (scalar(@_) == 0) {
 		$l->trace("trying to construct a temporary model");
 		my $dsn		= "dbi:SQLite:dbname=:memory:";
@@ -119,6 +120,7 @@ sub new {
 	} elsif (blessed($_[0]) and $_[0]->isa('DBI::db')) {
 		$l->trace("got a DBD handle");
 		$dbh		= shift;
+		$reconnect      = shift;
 		my $name	= $dbh->get_info(17);
 		if ($name eq 'MySQL') {
 			$class	= 'RDF::Trine::Store::DBI::mysql';
@@ -131,6 +133,7 @@ sub new {
 		my $dsn		= shift;
 		my $user	= shift;
 		my $pass	= shift;
+		$reconnect      = shift;
 		if ($dsn =~ /^DBI:mysql:/) {
 			$class	= 'RDF::Trine::Store::DBI::mysql';
 		} elsif ($dsn =~ /^DBI:Pg:/) {
@@ -153,7 +156,7 @@ sub new {
 		statements_table_prefix	=> 'Statements',
 		%args
 	}, $class );
-	$self->init();
+	$self->init() unless $reconnect;
 	return $self;
 }
 
@@ -170,7 +173,8 @@ sub _new_with_config {
 	return $class->new( $config->{name},
 			    $config->{dsn},
 			    $config->{username},
-			    $config->{password} );
+			    $config->{password},
+			    $config->{reconnect} );
 }
 
 sub _new_with_object {


### PR DESCRIPTION
This commit allows users to re-connect to an existing DBI store if they provide an additional flag to the constructor, either like this:

```
my $store = RDF::Trine::Store::DBI::mysql->new( $name, $dbh, my $reconnect = 1 );
```

...where a true value for the third argument means we re-connect as opposed to instantiating a new store, or like this:

```
my $store = RDF::Trine::Store::DBI::mysql->new_with_config( {
'name'      => $name,
'dsn'       => $dsn,
'username'  => $user,
'password'  => $pass,
'reconnect' => 1,
} );
```

...where a true value for the named argument 'reconnect' does the same. The use case that I'm thinking about is where I populate my triple store incrementally with bucket loads of small-ish rdf files, yet I want to run queries across them. Without this facility, it looks like everything needs to happen in one go, or else init() is called, which wipes the statements table. Apparently that is the intended behaviour, but it's not clear to me why.
