### PR TITLE
Added support of SPARQL endpoints with URL parameters

### DIFF
--- a/RDF-Trine/lib/RDF/Trine/Store/SPARQL.pm
+++ b/RDF-Trine/lib/RDF/Trine/Store/SPARQL.pm
@@ -511,7 +511,8 @@ sub get_sparql {
 	
 # 	warn $sparql;
 	
-	my $url			= $self->{url} . '?query=' . uri_escape($sparql);
+	my $url		= ($self->{url} =~ /\?/ ? '&' : '?');
+	my $url		= $self->{url} . $url . 'query=' . uri_escape($sparql);
 	my $response	= $ua->get( $url );
 	if ($response->is_success) {
 		$p->parse_string( $response->content );


### PR DESCRIPTION
SPARQL endpoints with URL parameters were not possible (like Virtuoso's 'http://example.org:8890/sparql?default-graph-uri=...')
