### PR TITLE
Check the Perl version when running Tiny::UUID

### DIFF
--- a/RDF-Trine/lib/RDF/Trine/Parser.pm
+++ b/RDF-Trine/lib/RDF/Trine/Parser.pm
@@ -385,7 +385,7 @@ a globally unique bnode prefix. Otherwise, an empty string is returned.
 
 sub new_bnode_prefix {
 	my $class	= shift;
-	if (defined($UUID::Tiny::VERSION) && ($] < 5.014000)) {
+	if (defined($UUID::Tiny::VERSION) && ($] < 5.014000)) { # UUID::Tiny 1.03 isn't working nice with thread support in Perl 5.14. When this is fixed, this may be removed and dep added.
 		no strict 'subs';
 		my $uuid	= UUID::Tiny::create_UUID_as_string(UUID::Tiny::UUID_V1);
 		$uuid		=~ s/-//g;


### PR DESCRIPTION
Hi!

Due to some test failures that I mentioned on IRC, I think Tiny::UUID may not be ready for use with the latest 5.14 interpreters, which adds threading. So, I figured it may be a good idea to use Data::UUID in this case. I guess one should check the version of Tiny::UUID too, since it may be fixed at some point, but that won't help now.

Here's a patch. It is completely untested (as I don't have 5.14 anyway), so just in case you would consider it.

Actually, wouldn't it be a good to check if Data::UUID is available first, since that has a faster XS implementation? I can see the argument for a pure-perl implementation, but I would prefer to use the XS stuff if available. :-) 
