### PR TITLE
Create a fallback-implementation of remove_statements in Store.pm

### DIFF
--- a/RDF-Trine/lib/RDF/Trine/Store.pm
+++ b/RDF-Trine/lib/RDF/Trine/Store.pm
@@ -382,7 +382,13 @@ Removes the specified C<$statement> from the underlying model.
 
 =cut
 
-sub remove_statements;
+sub remove_statements { # Fallback implementation
+  my $self = shift;
+  my $iterator = $self->get_statements(@_);
+  while (my $st = $iterator->next) {
+    $self->remove_statement($st);
+  }
+}
 
 =item C<< count_statements ($subject, $predicate, $object) >>
 

--- a/RDF-Trine/lib/RDF/Trine/Store/Hexastore.pm
+++ b/RDF-Trine/lib/RDF/Trine/Store/Hexastore.pm
@@ -585,12 +585,6 @@ sub remove_statement {
 
 Removes the specified C<$statement> from the underlying model.
 
-=cut
-
-sub remove_statements {
-	die;
-}
-
 =item C<< nuke >>
 
 Permanently removes all the data in the store.


### PR DESCRIPTION
Here's a patch that add a fallback implementation for remove_statements so that other implementations will not necessarily have to implement it.

Kjetil
