### PR TITLE
Log4perl woes

### DIFF
--- a/RDF-Trine/lib/RDF/Trine.pm
+++ b/RDF-Trine/lib/RDF/Trine.pm
@@ -67,7 +67,9 @@ use constant UNION_GRAPH	=> 'tag:gwilliams@cpan.org,2010-01-01:RT:ALL';
 use constant NIL_GRAPH		=> 'tag:gwilliams@cpan.org,2010-01-01:RT:NIL';
 
 use Log::Log4perl qw(:easy);
-Log::Log4perl->easy_init($ERROR);
+if (! Log::Log4perl::initialized() ) {
+    Log::Log4perl->easy_init($ERROR);
+}
 
 use RDF::Trine::Graph;
 use RDF::Trine::Parser;


### PR DESCRIPTION
RDF::Trine initializes Log4perl unconditionally. This leads to weird behavior in applications that use both Log4perl and RDF::Trine: Logging works as expected up to the point where RDF/Trine.pm is sourced when the Layout is reset and minimum log level set to $ERROR. This ccommit initializes Log4perl in RDF::Trine only if it wasn't initialized in the first place.
