### PR TITLE
Test for an empty body to XML parser?

### DIFF
--- a/RDF-Trine/t/parser.t
+++ b/RDF-Trine/t/parser.t
@@ -1,4 +1,4 @@
-use Test::More tests => 7;
+use Test::More tests => 9;
 use Test::Exception;
 
 use strict;
@@ -13,6 +13,12 @@ use RDF::Trine::Parser;
 throws_ok { RDF::Trine::Parser->new('guess') } 'RDF::Trine::Error::UnimplementedError', "Guess parser isn't implemented yet";
 throws_ok { RDF::Trine::Parser->new('foobar') } 'RDF::Trine::Error::ParserError', "RDF::Trine::Parser constructor throws on unrecognized parser name";
 
+{
+  my $rxparser     = RDF::Trine::Parser->new( 'rdfxml' );
+  my $model	= RDF::Trine::Model->temporary_model;
+  lives_ok { $rxparser->parse_into_model( 'http://example.org/', undef, $model ); } "Undef body to the parser doesn't die";
+  lives_ok { $rxparser->parse_into_model( 'http://example.org/', '', $model ); } "Empty body to the parser doesn't die";
+}
 
 SKIP: {
 	unless ($ENV{RDFTRINE_NETWORK_TESTS}) {


### PR DESCRIPTION
I've struggled for a while with a bug that was actually caused by that I was unknowingly passing an undef body to the RDF/XML parser. I figured, it should perhaps be more graceful, and not croak? 

So, I submit this patch to the tests, if you accept this, I could look into how it should be done.

Kjetil
