### PR TITLE
pass encoded data into parse_from_model()

### DIFF
--- a/RDF-Trine/t/parser-trig.t
+++ b/RDF-Trine/t/parser-trig.t
@@ -185,6 +185,8 @@ END
     }
 
 END
+	use Encode;
+	$trig = encode("utf-8", $trig);
 	$parser->parse_into_model(undef, $trig, $model);
 	my $iter = $model->get_statements( undef,
 					   RDF::Trine::Node::Resource->new('http://www.example.org/vocabulary#likes'),

--- a/RDF-Trine/t/parser-turtle.t
+++ b/RDF-Trine/t/parser-turtle.t
@@ -99,6 +99,8 @@ foreach my $file (@bad) {
 _:a foaf:name "Bob" . 
 _:a ex:likes "Blåbærsyltetøy"@no .
 END
+	use Encode;
+	$ttl = encode("utf-8", $ttl);
 	$parser->parse_into_model(undef, $ttl, $model);
 	my $iter = $model->get_statements( undef, iri('http://www.example.org/vocabulary#likes'), undef );
 	my $st = $iter->next;


### PR DESCRIPTION
The parser-trig.t and parser-turtle.t tests fail on blead perl since:

  open my $fh, $how, \$scalar

has changed to treat the code-points in $scalar as the bytes read instead of returning whatever happens to be the internal representation.

It isn't clear from the documentation whether parse_from_model() and parse() are intended to accept characters or to accept bytes, this patch assumes they are intended to accept bytes and encodes the data before supplying it to parse_from_model().

An alternative pull request that assumes parse() accepts characters will also be submitted.

For more information on the change, see:

http://blogs.perl.org/users/tony_cook/2013/02/perl-io-on-scalars.html

and

https://rt.perl.org/rt3/Ticket/Display.html?id=109828
