### PR TITLE
encode data passed into parse()

### DIFF
--- a/RDF-Trine/lib/RDF/Trine/Parser/Turtle.pm
+++ b/RDF-Trine/lib/RDF/Trine/Parser/Turtle.pm
@@ -86,6 +86,8 @@ sub parse {
 	local($self->{baseURI})	= shift;
 	my $string				= shift;
 	local($self->{handle_triple}) = shift;
+	require Encode;
+	$string = Encode::encode("utf-8", $string);
 	open(my $fh, '<:encoding(UTF-8)', \$string);
 	my $l	= RDF::Trine::Parser::Turtle::Lexer->new($fh);
 	$self->_parse($l);


### PR DESCRIPTION
This is the alternative to https://github.com/kasei/perlrdf/pull/81 that assumes parse_from_model() and parse() are intended to accept characters.

Whichever you choose you may also want to document which of characters or encoded bytes $data is meant to contain.
