### PR TITLE
Change Serializer to work fine with UTF-8 outputs.

### DIFF
--- a/RDF-Trine/lib/RDF/Trine/Serializer.pm
+++ b/RDF-Trine/lib/RDF/Trine/Serializer.pm
@@ -71,7 +71,7 @@ The valid key-values used in C<< %options >> are specific to a particular
 serializer implementation. For serializers that support namespace declarations
 (to allow more concise serialization), use C<< namespaces => \%namespaces >> in
 C<< %options >>, where the keys of C<< %namespaces >> are namespace names and
-the values are (partial) URIs. For serializers that support base URI declarations, 
+the values are (partial) URIs. For serializers that support base URI declarations,
 use C<< base_uri => $base_uri >> .
 
 =cut
@@ -81,7 +81,7 @@ sub new {
 	my $name	= shift;
 	my $key		= lc($name);
 	$key		=~ s/[^-a-z]//g;
-	
+
 	if (my $class = $serializer_names{ $key }) {
 		return $class->new( @_ );
 	} else {
@@ -96,7 +96,7 @@ RDF::Trine::Serializer object as decided by L<HTTP::Negotiate>.  If
 the C<< 'request_headers' >> key-value is supplied, the C<<
 $request_headers >> is passed to C<< HTTP::Negotiate::choose >>.  The
 option C<< 'restrict' >>, set to a list of serializer names, can be
-used to limit the serializers to choose from. Finally, an C<<'extend' >> 
+used to limit the serializers to choose from. Finally, an C<<'extend' >>
 option can be set to a hashref that contains MIME-types
 as keys and a custom variant as value. This will enable the user to
 use this negotiator to return a type that isn't supported by any
@@ -135,25 +135,25 @@ sub negotiate {
 		$qv		-= 0.01 if ($type =~ m#^application/(?!rdf[+]xml)#);	# prefer standard rdf/xml to other application/* formats
 		push(@default_variants, [$type, $qv, $type]);
 	}
-	
+
 	my %custom_thunks;
 	my @custom_variants;
 	while (my($type,$thunk) = each(%$extend)) {
 		push(@custom_variants, [$thunk, 1.0, $type]);
 		$custom_thunks{ $thunk }	= [$type, $thunk];
 	}
-	
+
 	# remove variants with media types that are in custom_variants from @variants
 	my @variants	= grep { not exists $extend->{ $_->[2] } } @default_variants;
 	push(@variants, @custom_variants);
-	
+
 	my $stype	= choose( \@variants, $headers );
 	if (defined($stype) and $custom_thunks{ $stype }) {
 		my $thunk	= $stype;
 		my $type	= $custom_thunks{ $stype }[0];
 		return ($type, $thunk);
 	}
-	
+
 	if (defined($stype) and my $sclass = $media_types{ $stype }) {
 		return ($stype, $sclass->new( %options ));
 	} else {
@@ -193,7 +193,10 @@ sub serialize_model_to_string {
 	my $self	= shift;
 	my $model	= shift;
 	my $string	= '';
-	open( my $fh, '>:encoding(UTF-8)', \$string );
+
+    # :raw because using :utf8 layer double encode UTF-8
+    # What is already in a perl unicode string [internally UTF-8] to in-memory handle.
+	open( my $fh, '>:raw', \$string );
 	$self->serialize_model_to_file( $fh, $model );
 	close($fh);
 	return $string;

--- a/RDF-Trine/lib/RDF/Trine/Serializer/RDFJSON.pm
+++ b/RDF-Trine/lib/RDF/Trine/Serializer/RDFJSON.pm
@@ -84,7 +84,7 @@ sub serialize_model_to_file {
 	my $file	  = shift;
 	my $model  = shift;
 	my $opts   = shift;
-	my $string = to_json($model->as_hashref, $opts);
+	my $string = $opts ? to_json($model->as_hashref, $opts) : encode_json($model->as_hashref);
 	print {$file} $string;
 }
 
@@ -100,7 +100,7 @@ sub serialize_model_to_string {
 	my $self	  = shift;
 	my $model  = shift;
 	my $opts   = shift;
-	my $string = to_json($model->as_hashref, $opts);
+	my $string = $opts ? to_json($model->as_hashref, $opts) : encode_json($model->as_hashref);
 	return $string;
 }
 


### PR DESCRIPTION
I had some problems with double-encoding on RDFXML and missing encoding on RDFJSON, and then, after trying a lot of things, that is what I've find.

N-Tripes are/were fine because chars is represented in \x{xx} 

Please consider testing it before update CPAN.

Bump version is also needled.
