### PR TITLE
Do not search modules in relative paths

### DIFF
--- a/RDF-Query/bin/rqsh
+++ b/RDF-Query/bin/rqsh
@@ -2,7 +2,6 @@
 use strict;
 use warnings;
 no warnings 'redefine';
-use lib qw(../lib lib);
 
 use Cwd;
 use Benchmark;


### PR DESCRIPTION
This is insecure as a local attacker can create rogue modules in
current working directory.