### PR TITLE
RDF::Trine::Store::SPARQL::_group_bulk_ops doesn't build array correc…

### DIFF
--- a/RDF-Trine/lib/RDF/Trine/Store/SPARQL.pm
+++ b/RDF-Trine/lib/RDF/Trine/Store/SPARQL.pm
@@ -574,9 +574,9 @@ sub _end_bulk_ops {
 		my @aggops	= $self->_group_bulk_ops( @ops );
 		my @sparql;
 		foreach my $aggop (@aggops) {
-			my ($type, @ops)	= @$aggop;
+			my ($type, $ops)	= @$aggop;
 			my $method	= "${type}_sparql";
-			push(@sparql, $self->$method( @ops ));
+			push(@sparql, $self->$method( @$ops ));
 		}
 		my $sparql	= join(";\n", @sparql);
 		my $iter	= $self->_get_post_iterator( $sparql );
@@ -593,14 +593,14 @@ sub _group_bulk_ops {
 	
 	my $op		= shift(@ops);
 	my $type	= $op->[0];
-	push(@bulkops, [$type, [ @{$op}[1 .. $#{ $op }] ]]);
+	push(@bulkops, [$type, [[ @{$op}[1 .. $#{ $op }] ]]]);
 	while (scalar(@ops)) {
 		my $op	= shift(@ops);
 		my $type	= $op->[0];
 		if ($op->[0] eq $bulkops[ $#bulkops ][0]) {
 			push( @{ $bulkops[ $#bulkops ][1] }, [ @{$op}[1 .. $#{ $op }] ] );
 		} else {
-			push(@bulkops, [$type, [ @{$op}[1 .. $#{ $op }] ]]);
+			push(@bulkops, [$type, [[ @{$op}[1 .. $#{ $op }] ]]]);
 		}
 	}
 	


### PR DESCRIPTION
As per issue #146 on Github, there were issues where
RDF::Trine::Store::SPARQL::_group_bulk_ops was pushing additional ops
into the element of the first op in the @aggops array.

There was also an issue with RDF::Trine::Store::SPARQL::_end_bulk_ops
where the ops were being added to a new array rather than assigned
as a reference.

This commit fixes these two assignment problems, and adds some tests
to make sure that these fixes work.

TEST PLAN:
Within 'perlrdf/RDF-Trine' run the following:
perl -I lib xt/store-sparql.t

All tests should pass. If you already have RDF::Trine
installed on your system, leave off the -I switch and
chances are the tests will fail (at least if you're using v1.016).