### PR TITLE
API inconsistent between RDF::Trine::Store::Memory and RDF::Trine::St…

### DIFF
--- a/RDF-Trine/lib/RDF/Trine/Store/SPARQL.pm
+++ b/RDF-Trine/lib/RDF/Trine/Store/SPARQL.pm
@@ -366,8 +366,21 @@ Removes the specified C<$statement> from the underlying model.
 
 sub remove_statements {
 	my $self	= shift;
-	my $st		= shift;
-	my $context	= shift;
+	my $st		= $_[0];
+    my $context;
+    if ( $st->isa("RDF::Trine::Statement") ){
+        $context = $_[1];
+    }
+    else {
+        my ($subj,$pred,$obj) = @_[ 0..2 ];
+        $context = $_[3];
+        if ($context){
+            $st = RDF::Trine::Statement::Quad->new($subj,$pred,$obj,$context);
+        }
+        else {
+            $st = RDF::Trine::Statement->new($subj,$pred,$obj);
+        }
+    }
 	
 	unless (blessed($st) and $st->isa('RDF::Trine::Statement')) {
 		throw RDF::Trine::Error::MethodInvocationError -text => "Not a valid statement object passed to remove_statements";


### PR DESCRIPTION
As per issue #149 on Github, RDF::Trine::Store::SPARQL doesn't implement
the remove_statements() function interface in accordance with the documentation
or all the other RDF::Trine::Store::* modules. It takes ($statement,$context)
parameters instead of ($subj,$pred,$ojb,$context) parameters.

This patch keeps this inconsistent behaviour so as to be backwards
compatible, but also provides support for the interface referenced
in the documentation and implemented by other storage backends.

This patch also includes unit tests to check both sets of parameters
with and without context.