### PR TITLE
Fix handling of gzip-encoded content

### DIFF
--- a/RDF-Trine/lib/RDF/Trine/Parser.pm
+++ b/RDF-Trine/lib/RDF/Trine/Parser.pm
@@ -207,7 +207,7 @@ sub parse_url_into_model {
 		throw RDF::Trine::Error::ParserError -text => $resp->status_line;
 	}
 	
-	my $content	= $resp->content;
+	my $content	= $resp->decoded_content;
 	if (my $cb = $args{content_cb}) {
 		$cb->( $url, $content, $resp );
 	}


### PR DESCRIPTION
For example, http://schema.org/version/3.3/schema.rdf is gzip encoded.
This is fixed simply by using the LWP::UserAgent decoded_content
method instead of the (raw) content method.